### PR TITLE
Docblock enumerations with `static` type qualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ namespace X;
 use Thunder\Platenum\Enum\ConstantsEnumTrait;
 
 /**
- * @method static self ACTIVE()
- * @method static self INACTIVE()
- * @method static self SUSPENDED()
- * @method static self DISABLED()
+ * @method static static ACTIVE()
+ * @method static static INACTIVE()
+ * @method static static SUSPENDED()
+ * @method static static DISABLED()
  */
 final class AccountStatusEnum
 {
@@ -114,8 +114,8 @@ final class BooleanEnum extends AbstractConstantsEnum
 
 ```php
 /**
- * @method static self TRUE()
- * @method static self FALSE()
+ * @method static static TRUE()
+ * @method static static FALSE()
  */
 final class BooleanEnum
 {
@@ -125,8 +125,8 @@ final class BooleanEnum
 
 ```php
 /**
- * @method static self TRUE()
- * @method static self FALSE()
+ * @method static static TRUE()
+ * @method static static FALSE()
  */
 final class BooleanEnum extends AbstractDocblockEnum {}
 ```

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -120,7 +120,7 @@ final class GenerateCommand
             }
 
             $constantsEntries[] = '    private const '.strtoupper($key).' = '.$value.';';
-            $docblockEntries[] = ' * @method static self '.strtoupper($key).'()';
+            $docblockEntries[] = ' * @method static static '.strtoupper($key).'()';
             $staticEntries[] = '        \''.strtoupper($key).'\' => '.$value.';';
         }
 

--- a/src/Enum/DocblockEnumTrait.php
+++ b/src/Enum/DocblockEnumTrait.php
@@ -19,7 +19,7 @@ trait DocblockEnumTrait
             throw PlatenumException::fromMissingDocblock($class);
         }
 
-        if(\preg_match_all('~^\s+\*\s+@method\s+static\s+self\s+(?<key>\w+)\(\)$~m', $doc, $matches) < 1) {
+        if(\preg_match_all('~^\s+\*\s+@method\s+static\s+(?:self|static)\s+(?<key>\w+)\(\)$~m', $doc, $matches) < 1) {
             throw PlatenumException::fromEmptyDocblock($class);
         }
         if(\count($matches['key']) !== substr_count($doc, '@method')) {

--- a/tests/DocblockEnumTest.php
+++ b/tests/DocblockEnumTest.php
@@ -22,6 +22,20 @@ final class DocblockEnumTest extends AbstractTestCase
         $this->assertSame($expected, $extends::getMembersAndValues());
     }
 
+    public function testAcceptBothSelfAndStaticDocblockTypeQualifiers(): void
+    {
+        /** @var FakeEnum $enum */
+        $enum = $this->computeUniqueClassName('X');
+        eval('/**
+         * @method static self FIRST()
+         * @method static static SECOND()
+         */
+        class '.$enum.' { use '.DocblockEnumTrait::class.'; }');
+
+        $this->assertSame('FIRST', $enum::FIRST()->getValue());
+        $this->assertSame('SECOND', $enum::SECOND()->getValue());
+    }
+
     public function testExceptionDocblockNotPresent(): void
     {
         /** @var FakeEnum $enum */


### PR DESCRIPTION
PHPStorm does not recognize members created with `self` as instances of a given class. This PR resolves the issue reported in #2.

- [x] updated `GenerateCommand` to generate `static` type qualifiers in `@method` declarations,
- [x] updated `DocblockEnumTrait` to accept both `self` and `static` type qualifiers in `@method` declarations,
- [x] replaced all mentions of `@method static self MEMBER()` with `static static` in README.