### PR TITLE
Generator autoloader path

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -5,8 +5,16 @@ namespace X;
 
 use Thunder\Platenum\Command\GenerateCommand;
 
-$vendorLoaderPath  = dirname(__DIR__, 3).'/vendor/autoload.php';
+$vendorLoaderPath  = dirname(__DIR__, 4).'/vendor/autoload.php';
 $packageLoaderPath = dirname(__DIR__, 1).'/vendor/autoload.php';
-$loader = require file_exists($vendorLoaderPath) ? $vendorLoaderPath : $packageLoaderPath;
+
+if(file_exists($vendorLoaderPath)) {
+    $loader = require $vendorLoaderPath;
+} elseif(file_exists($packageLoaderPath)) {
+    $loader = require $packageLoaderPath;
+} else {
+    echo 'There is no autoloader present. Did you run composer install?'."\n";
+    exit(1);
+}
 
 (new GenerateCommand($loader))->execute($argc, $argv);

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -29,8 +29,10 @@ final class GenerateCommand
         $this->writeln('');
 
         if($argc < 4) {
-            $this->writeln('usage: bin/generate source class keys,values');
-            $this->writeln('       bin/generate constants MyEnum key1,key2=value2,key3');
+            $this->writeln('usage:    bin/generate <source> <class> MEMBER=value,MEMBER=value,...');
+            $this->writeln('examples: bin/generate constants UserStatus ACTIVE=1,INACTIVE=2');
+            $this->writeln('          bin/generate docblock PaymentType INTERNAL,EXTERNAL');
+            $this->writeln('          bin/generate static "Project\\Namespace\\Currency" PLN=10,EUR=12,USD=14');
             exit(1);
         }
         if(false === in_array($argv[1], ['constants', 'docblock', 'static'], true)) {


### PR DESCRIPTION
When Platenum is used as a vendor package, the autoloader should be loaded from root package vendor directory.