### PR TITLE
Custom exception classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,35 @@ final class BooleanEnum
 }
 ```
 
+## Exceptions
+
+The library throws default `PlatenumException` with dedicated message for all errors happening in the enum classes. Certain situations may require a dedicated exception class and message. To redefine the exception logic, override one or more of the static methods described below:
+
+- `throwInvalidMemberException()` used when enum receives an invalid enum **member** in any method,
+- `throwInvalidValueException()` used when enum receives an invalid enum **value** in any method.
+
+> NOTE: If the overridden method won't throw an exception, the library contains a safeguard which will still throw the default one. This way a development oversight won't hide errors in your application.
+
+```php
+final class AccountStatus
+{
+    use ConstantsEnumTrait;
+
+    private const ACTIVE = 1;
+    private const DISABLED = 2;
+
+    protected static function throwInvalidMemberException(string $name): void
+    {
+        throw new InvalidAccountStatusException($name);
+    }
+
+    protected static function throwInvalidValueException($value): void
+    {
+        throw new InvalidAccountStatusValueException($value);
+    }
+}
+```
+
 ## Reasons
 
 There are already a few `enum` libraries in the PHP ecosystem. Why another one? There are several reasons to do so:

--- a/src/Exception/PlatenumException.php
+++ b/src/Exception/PlatenumException.php
@@ -7,6 +7,20 @@ namespace Thunder\Platenum\Exception;
  */
 final class PlatenumException extends \LogicException
 {
+    /* --- OVERRIDE --- */
+
+    public static function fromInvalidMember(string $fqcn, string $member, array $members): self
+    {
+        return new self(sprintf('Enum `%s` does not contain member `%s` among `%s`.', $fqcn, $member, implode(',', array_keys($members))));
+    }
+
+    public static function fromInvalidValue(string $fqcn, $value): self
+    {
+        return new self(sprintf('Enum `%s` does not contain any member with value `%s`.', $fqcn, $value));
+    }
+
+    /* --- GENERIC --- */
+
     public static function fromIllegalValue(string $fqcn, $value): self
     {
         return new self(sprintf('Enum `%s` value must be a scalar, `%s` given.', $fqcn, gettype($value)));
@@ -15,16 +29,6 @@ final class PlatenumException extends \LogicException
     public static function fromMismatchedClass(string $fqcn, string $other): self
     {
         return new self(sprintf('Attempting to recreate enum %s from instance of %s.', $fqcn, $other));
-    }
-
-    public static function fromMissingMember(string $fqcn, string $member, array $members): self
-    {
-        return new self(sprintf('Enum `%s` does not contain member `%s` among `%s`.', $fqcn, $member, implode(',', array_keys($members))));
-    }
-
-    public static function fromMissingValue(string $fqcn, $value): self
-    {
-        return new self(sprintf('Enum `%s` does not contain any member with value `%s`.', $fqcn, $value));
     }
 
     public static function fromConstantArguments(string $fqcn): self

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -25,7 +25,7 @@ abstract class AbstractTestCase extends TestCase
             $entries[] = sprintf('%s => %s', '\''.$member.'\'', is_string($value) ? '\''.$value.'\'' : $value);
         }
 
-        $class = $this->computeUniqueClassName('DocblockTrait');
+        $class = $this->computeUniqueClassName('RawEnum');
         eval('final class '.$class.' implements \JsonSerializable {
             use '.EnumTrait::class.';
             private static function resolve(): array { return ['.implode(', ', $entries).']; }


### PR DESCRIPTION
This PR allows configuration of custom exception classes by overriding certain methods on the target enumeration class:
- [x] `Enum::INVALID()` -> `throwInvalidMemberException()`,
- [x] `Enum::fromMember('INVALID')` -> `throwInvalidMemberException()`,
- [x] `Enum::fromValue('invalid')` -> `throwInvalidValueException()`.

Also:
- [x] updated README,
- [x] simplified `EnumTrait::__callStatic()`,
- [x] renamed a few methods in `PlatenumException`,
- [x] added a test for custom exceptions handling.