### PR TITLE
Fixes create from value on subclasses

### DIFF
--- a/src/Enum/EnumTrait.php
+++ b/src/Enum/EnumTrait.php
@@ -77,7 +77,7 @@ trait EnumTrait
             return static::$instances[$class][$name];
         }
 
-        return static::$instances[$class][$name] = new self($name, static::$members[$class][$name]);
+        return static::$instances[$class][$name] = new static($name, static::$members[$class][$name]);
     }
 
     final public static function fromEnum($enum): self


### PR DESCRIPTION
This fixes creating instances using the `fromValue()` method on sub-classes.