### PR TITLE
Callback source

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,41 @@ final class BooleanEnum extends AbstractStaticEnum
 }
 ```
 
+**callback**
+
+```php
+final class Currency
+{
+    use CallbackEnumTrait;
+}
+```
+
+```php
+final class Currency extends AbstractCallbackEnum
+{
+}
+```
+
+Unlike other types, callback enum requires initialization before creating member instances. To make it ready to use, run `initialize()` method with a callback returning `member => value` mapping (similar to `StaticEnumTrait`). This callback will be run exactly once right before creating the first member instance:
+
+```php
+Currency::initialize(fn() => [
+    'PLN' => 985,
+    'EUR' => 978,
+    'USD' => 840,
+]);
+```
+
+> NOTE: This type allows loading members and values mapping from virtually any external place (database, Redis, session, files, etc.). The only requirement for this callable is that it returns a proper `member => value` pairs.
+
+```php
+Currency::initialize(fn() => SomeClass::CONSTANT);
+Currency::initialize(fn() => $database->sql('...'));
+Currency::initialize(fn() => $redis->hGetAll('...'));
+Currency::initialize(fn() => json_decode(file_get_contents('...')));
+// etc.
+```
+
 **custom source**
 
 > Note: The `resolve` method will be called only once when the enumeration is used for the first time.

--- a/src/Enum/AbstractCallbackEnum.php
+++ b/src/Enum/AbstractCallbackEnum.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+namespace Thunder\Platenum\Enum;
+
+/**
+ * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
+ */
+abstract class AbstractCallbackEnum implements \JsonSerializable
+{
+    use CallbackEnumTrait;
+}

--- a/src/Enum/CallbackEnumTrait.php
+++ b/src/Enum/CallbackEnumTrait.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace Thunder\Platenum\Enum;
+
+use Thunder\Platenum\Exception\PlatenumException;
+
+/**
+ * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
+ */
+trait CallbackEnumTrait
+{
+    use EnumTrait;
+
+    /** @var non-empty-array<class-string,callable():array<string,int|string>> */
+    protected static $callbacks = [];
+
+    /** @param callable():array<string,int|string> $callback */
+    final public static function initialize(callable $callback): void
+    {
+        if(array_key_exists(static::class, static::$callbacks)) {
+            throw PlatenumException::fromAlreadyInitializedCallback(static::class);
+        }
+
+        static::$callbacks[static::class] = $callback;
+    }
+
+    final private static function resolve(): array
+    {
+        if(false === array_key_exists(static::class, static::$callbacks)) {
+            throw PlatenumException::fromInvalidCallback(static::class);
+        }
+        if(false === is_callable(static::$callbacks[static::class])) {
+            throw PlatenumException::fromInvalidCallback(static::class);
+        }
+
+        return (static::$callbacks[static::class])();
+    }
+}

--- a/src/Enum/EnumTrait.php
+++ b/src/Enum/EnumTrait.php
@@ -92,7 +92,7 @@ trait EnumTrait
 
     /**
      * @param static $enum
-     * @param-out AbstractConstantsEnum|AbstractDocblockEnum|AbstractStaticEnum $enum
+     * @param-out AbstractConstantsEnum|AbstractDocblockEnum|AbstractStaticEnum|AbstractCallbackEnum $enum
      */
     final public function fromInstance(&$enum): void
     {
@@ -254,6 +254,12 @@ trait EnumTrait
         }
         if(\count($members) !== \count(\array_unique($members))) {
             throw PlatenumException::fromNonUniqueMembers($class);
+        }
+        if(['string'] !== \array_unique(\array_map('gettype', array_keys($members)))) {
+            throw PlatenumException::fromNonStringMembers($class);
+        }
+        if(1 !== \count(\array_unique(\array_map('gettype', $members)))) {
+            throw PlatenumException::fromNonUniformMemberValues($class, $members);
         }
 
         static::$members[$class] = $members;

--- a/src/Exception/PlatenumException.php
+++ b/src/Exception/PlatenumException.php
@@ -58,6 +58,16 @@ final class PlatenumException extends \LogicException
         return new self(sprintf('Enum `%s` does not allow magic `%s` method.', $fqcn, $method));
     }
 
+    public static function fromNonStringMembers(string $fqcn): self
+    {
+        return new self(sprintf('Enum `%s` requires all members to be strings.', $fqcn));
+    }
+
+    public static function fromNonUniformMemberValues(string $fqcn, array $members): self
+    {
+        return new self(sprintf('Enum `%s` member values must be of the same type, `%s` given.', $fqcn, implode(',', array_unique(array_map('gettype', $members)))));
+    }
+
     /* --- DOCBLOCK --- */
 
     public static function fromMissingDocblock(string $fqcn): self
@@ -80,5 +90,17 @@ final class PlatenumException extends \LogicException
     public static function fromMissingMappingProperty(string $fqcn): self
     {
         return new self(sprintf('Enum %s requires static property $mapping with members definitions.', $fqcn));
+    }
+
+    /* --- CALLBACK --- */
+
+    public static function fromInvalidCallback(string $fqcn): self
+    {
+        return new self(sprintf('Enum %s requires static property $callback to be a valid callable returning members and values mapping.', $fqcn));
+    }
+
+    public static function fromAlreadyInitializedCallback(string $fqcn): self
+    {
+        return new self(sprintf('Enum %s callback was already initialized.', $fqcn));
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 namespace Thunder\Platenum\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Thunder\Platenum\Enum\AbstractCallbackEnum;
 use Thunder\Platenum\Enum\AbstractConstantsEnum;
 use Thunder\Platenum\Enum\AbstractDocblockEnum;
 use Thunder\Platenum\Enum\AbstractStaticEnum;
+use Thunder\Platenum\Enum\CallbackEnumTrait;
 use Thunder\Platenum\Enum\ConstantsEnumTrait;
 use Thunder\Platenum\Enum\DocblockEnumTrait;
 use Thunder\Platenum\Enum\EnumTrait;
@@ -114,6 +116,24 @@ abstract class AbstractTestCase extends TestCase
 
         $class = $this->computeUniqueClassName('StaticExtends');
         eval('final class '.$class.' extends '.AbstractStaticEnum::class.' { protected static $mapping = ['.implode(', ', $entries).']; }');
+
+        return $class;
+    }
+
+    /** @return FakeEnum */
+    protected function makeCallbackTraitEnum(array $members): string
+    {
+        $class = $this->computeUniqueClassName('CallbackTrait');
+        eval('final class '.$class.' implements \JsonSerializable { use '.CallbackEnumTrait::class.'; }');
+
+        return $class;
+    }
+
+    /** @return FakeEnum */
+    protected function makeCallbackExtendsEnum(array $members): string
+    {
+        $class = $this->computeUniqueClassName('CallbackExtends');
+        eval('final class '.$class.' extends '.AbstractCallbackEnum::class.' { }');
 
         return $class;
     }

--- a/tests/CallbackEnumTest.php
+++ b/tests/CallbackEnumTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+namespace Thunder\Platenum\Tests;
+
+use Thunder\Platenum\Exception\PlatenumException;
+
+/**
+ * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
+ */
+final class CallbackEnumTest extends AbstractTestCase
+{
+    public function testMembers(): void
+    {
+        $members = ['FIRST' => 1, 'SECOND' => 2];
+        $trait = $this->makeCallbackTraitEnum($members);
+        $trait::initialize(function() use($members) { return $members; });
+        $extends = $this->makeCallbackExtendsEnum($members);
+        $extends::initialize(function() use($members) { return $members; });
+
+        $expected = ['FIRST' => 1, 'SECOND' => 2];
+        $this->assertSame($expected, $trait::getMembersAndValues());
+        $this->assertSame($expected, $extends::getMembersAndValues());
+    }
+
+    public function testExceptionNoInitialize(): void
+    {
+        $members = ['FIRST' => 1, 'SECOND' => 2];
+        $class = $this->makeCallbackTraitEnum($members);
+
+        $this->expectException(PlatenumException::class);
+        $this->expectExceptionMessage('Enum '.$class.' requires static property $callback to be a valid callable returning members and values mapping.');
+        $class::FIRST();
+    }
+
+    public function testExceptionAlreadyInitialized(): void
+    {
+        $members = ['FIRST' => 1, 'SECOND' => 2];
+        $class = $this->makeCallbackTraitEnum($members);
+        $class::initialize(function() use($members) { return $members; });
+
+        $this->expectException(PlatenumException::class);
+        $this->expectExceptionMessage('Enum '.$class.' callback was already initialized.');
+        $class::initialize(function() use($members) { return $members; });
+    }
+}

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -136,6 +136,24 @@ final class EnumTest extends AbstractTestCase
         $enum::FIRST();
     }
 
+    public function testExceptionNonStringMember(): void
+    {
+        $enum = $this->makeRawEnum([42 => 'invalid']);
+
+        $this->expectException(PlatenumException::class);
+        $this->expectExceptionMessage('Enum `'.$enum.'` requires all members to be strings.');
+        $enum::fromValue(42);
+    }
+
+    public function testExceptionNonUniformValueType(): void
+    {
+        $enum = $this->makeRawEnum(['FIRST' => 1, 'SECOND' => '2']);
+
+        $this->expectException(PlatenumException::class);
+        $this->expectExceptionMessage('Enum `'.$enum.'` member values must be of the same type, `integer,string` given.');
+        $enum::fromValue(42);
+    }
+
     /* --- GENERIC --- */
 
     public function testExtendedExtendedEnum(): void


### PR DESCRIPTION
Callback source requires external initialization with callable value (`::initialize($callback)`) which will be saved in the class and called on the first interaction with given enumeration. This allows enumerations members and values to be loaded from virtually any place by passing necessary data from outside. This includes database tables, Redis, files, sessions, runtime configurations, etc.

- [x] introduce callback enum types,
- [x] verify that all members are strings,
- [x] verify that all values are of the same type.