### PR TITLE
Psalm 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
+PHP_VERSION ?= 7.4
+COMPOSER := docker-compose run --rm composer
+PHP := docker-compose run --rm php-${PHP_VERSION}
+
 composer-install:
-	PHP_VERSION=7.4 docker-compose run --rm composer composer install
+	${COMPOSER} composer install
+composer-self-update:
+	${COMPOSER} composer self-update
 composer-update:
-	PHP_VERSION=7.4 docker-compose run --rm composer composer update
+	${COMPOSER} composer update
 composer-require:
-	PHP_VERSION=7.4 docker-compose run --rm composer composer require ${PACKAGE}
+	${COMPOSER} composer require ${PACKAGE}
 composer-require-dev:
-	PHP_VERSION=7.4 docker-compose run --rm composer composer require --dev ${PACKAGE}
+	${COMPOSER} composer require --dev ${PACKAGE}
 
 test: test-phpunit
 test-phpunit:
-	PHP_VERSION=7.4 docker-compose run --rm php php -v
-	PHP_VERSION=7.4 docker-compose run --rm php php vendor/bin/phpunit --coverage-text
+	${PHP} php -v
+	${PHP} php vendor/bin/phpunit --coverage-text
 	make test-infection
 	make qa-psalm
 test-phpunit-local:
@@ -19,7 +25,7 @@ test-phpunit-local:
 	php vendor/bin/psalm --no-cache
 	php vendor/bin/infection
 test-infection:
-	PHP_VERSION=7.4 docker-compose run --rm php php vendor/bin/infection -j2
+	${PHP} php vendor/bin/infection -j2
 
 travis:
 	PHP_VERSION=7.1.3 make travis-job
@@ -29,13 +35,13 @@ travis:
 	PHP_VERSION=7.4 docker-compose run --rm composer composer config --unset platform
 travis-job:
 	docker-compose run --rm composer composer config platform.php ${PHP_VERSION}
-	docker-compose run --rm composer composer update -q
-	PHP_VERSION=${PHP_VERSION} docker-compose run --rm php php -v
-	PHP_VERSION=${PHP_VERSION} docker-compose run --rm php php vendor/bin/phpunit
-	PHP_VERSION=${PHP_VERSION} docker-compose run --rm php php vendor/bin/psalm --no-cache
+	docker-compose run --rm composer composer update
+	${PHP} php -v
+	${PHP} php vendor/bin/phpunit
+	${PHP} php vendor/bin/psalm --no-cache
 
 qa-psalm:
-	PHP_VERSION=7.4 docker-compose run --rm php php vendor/bin/psalm --no-cache
+	${PHP} php vendor/bin/psalm --no-cache
 
 run-php:
-	PHP_VERSION=7.4 docker-compose run --rm php php ${FILE}
+	${PHP} php ${FILE}

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require-dev": {
         "ext-json": "*",
         "phpunit/phpunit": ">=6.0",
-        "hirak/prestissimo": "^0.3.8",
-        "vimeo/psalm": "^3.14",
+        "vimeo/psalm": ">=3.14",
         "doctrine/dbal": "^2.9",
         "doctrine/orm": "^2.7",
         "infection/infection": ">=0.13"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,15 +4,10 @@ services:
 
   composer:
     image: composer
-    volumes:
-      - .:/app
-    working_dir: /app
+    volumes: ['.:/app']
+    working_dir: '/app'
 
-  php:
-    build:
-      context: docker/php
-      args:
-        PHP_VERSION: ${PHP_VERSION:-7.4}
-    volumes:
-      - .:/app
-    working_dir: /app
+  php-7.1.3: { image: 'php:7.1.3', volumes: ['.:/app'], working_dir: /app }
+  php-7.2:   { image: 'php:7.2',   volumes: ['.:/app'], working_dir: /app }
+  php-7.3:   { image: 'php:7.3',   volumes: ['.:/app'], working_dir: /app }
+  php-7.4:   { image: 'php:7.4',   volumes: ['.:/app'], working_dir: /app }

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,7 @@
     totallyTyped="true"
     errorLevel="1"
     resolveFromConfigFile="true"
+    findUnusedPsalmSuppress="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">

--- a/src/Enum/EnumTrait.php
+++ b/src/Enum/EnumTrait.php
@@ -58,7 +58,6 @@ trait EnumTrait
     /**
      * @param mixed $value
      * @return static
-     * @psalm-suppress MoreSpecificReturnType
      */
     final public static function fromValue($value): self
     {


### PR DESCRIPTION
- [x] allowed Psalm 4.0 (`>=3.14`),
- [x] removed unused Psalm suppressions,
- [x] reorganized Makefile, replaced common command prefixes with variables,
- [x] `make travis` now uses correct PHP versions,
- [x] dropped `hirak/prestissimo`, Composer 2.0 is wicked fast,
- [ ] unfortunately automatic detection of unused suppression fails in CI, older Psalm version detect them as violations.